### PR TITLE
added iterator remove, re-arranged some functions in InternaOakHash/M…

### DIFF
--- a/core/src/main/java/com/yahoo/oak/BasicChunk.java
+++ b/core/src/main/java/com/yahoo/oak/BasicChunk.java
@@ -66,6 +66,8 @@ abstract class BasicChunk<K, V> {
 
     abstract boolean readValueFromEntryIndex(ValueBuffer value, int ei);
 
+    abstract void lookUp(ThreadContext ctx, K key);
+
     /*-------------- Publishing related methods and getters ---------------*/
     /**
      * publish operation so rebalance will wait for it
@@ -171,12 +173,12 @@ abstract class BasicChunk<K, V> {
 
     /*----------------------- Abstract Mappings-related Methods  --------------------------*/
     /**
-     * See concrete implementation for more information
+     * See specific implementation for more information
      */
     abstract void releaseKey(ThreadContext ctx);
 
     /**
-     * See concrete implementation for more information
+     * See specific implementation for more information
      */
     abstract void releaseNewValue(ThreadContext ctx);
 

--- a/core/src/main/java/com/yahoo/oak/InternalOakHash.java
+++ b/core/src/main/java/com/yahoo/oak/InternalOakHash.java
@@ -91,6 +91,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
     /*-------------- Hash API Methods --------------*/
     // put the value associated with the key, if key existed old value is overwritten
+    @Override
     V put(K key, V value, OakTransformer<V> transformer) {
         if (key == null || value == null) {
             throw new NullPointerException();
@@ -101,12 +102,13 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         for (int i = 0; i < MAX_RETRIES; i++) {
 
             // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+            HashChunk<K, V> c = findChunk(key, ctx);
             c.lookUp(ctx, key);
             // If there is a matching value reference for the given key, and it is not marked as deleted,
             // then this put changes the slice pointed by this value reference.
             if (ctx.isValueValid()) {
                 // there is a value and it is not deleted
+
                 Result res = config.valueOperator.exchange(c, ctx, value, transformer, getValueSerializer());
                 if (res.operationResult == ValueUtils.ValueResult.TRUE) {
                     return (V) res.value;
@@ -135,7 +137,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
     // returns false if restart and new search for the chunk is required
     private boolean publishAndWriteKey(HashChunk<K, V> c, ThreadContext ctx, K key, V value) {
-        // for Hash case it is not necessary to help to finialize deletion of the found
+        // for Hash case it is not necessary to help to finalize deletion of the found
         // (during lookup) entry as another entry may be chosen later (during allocation)
         if (isAfterRebalanceOrValueUpdate(c, ctx)) {
             return false;
@@ -143,7 +145,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
         // For OakHash publish the put earlier (compared to OakMap) in order to invoke delete
         // finalization (part of c.allocateEntryAndWriteKey) within publish/unpublish scope.
-        // Delete finalization needs to be invoked within within publish/unpublish scope,
+        // Delete finalization needs to be invoked within publish/unpublish scope,
         // to ensure each slice is released only once
         if (!c.publish()) {
             rebalance(c);
@@ -154,7 +156,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         // (1) Key wasn't found (key and value not valid)
         // (2) Key was found as part of deleted entry and deletion was accomplished if needed
         if (!c.allocateEntryAndWriteKey(ctx, key)) {
-            // allocation wasn't successfull and resulted in rebalance - retry
+            // allocation wasn't successful and resulted in rebalance - retry
             // currently cannot happen as rebalance is never requested due to too much collisions
             c.unpublish();
             rebalance(c);
@@ -185,85 +187,11 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
     boolean refreshValuePosition(ThreadContext ctx) {
         K deserializedKey = getKeySerializer().deserialize(ctx.key);
         // find chunk matching key, puts this key hash into ctx.operationKeyHash
-        HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(deserializedKey, ctx));
+        HashChunk<K, V> c = findChunk(deserializedKey, ctx);
         c.lookUp(ctx, deserializedKey);
         return ctx.isValueValid();
     }
 
-    // if key exists, remove the key-value mapping from the map
-    Result remove(K key, V oldValue, OakTransformer<V> transformer) {
-        if (key == null) {
-            throw new NullPointerException();
-        }
-
-        // when logicallyDeleted is true, it means we have marked the value as deleted.
-        // Note that the entry will remain linked until rebalance happens.
-        boolean logicallyDeleted = false;
-        V v = null;
-
-        ThreadContext ctx = getThreadContext();
-
-        for (int i = 0; i < MAX_RETRIES; i++) {
-            // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
-            c.lookUp(ctx, key);
-
-            if (!ctx.isKeyValid()) {
-                // There is no such key. If we did logical deletion and someone else did the physical deletion,
-                // then the old value is saved in v. Otherwise v is (correctly) null
-                return transformer == null ? ctx.result.withFlag(logicallyDeleted) : ctx.result.withValue(v);
-            } else if (!ctx.isValueValid()) {
-                // There is such a key, but the value is invalid,
-                // either deleted (maybe only off-heap) or not yet allocated
-                if (!finalizeDeletion(c, ctx)) {
-                    // finalize deletion returns false, meaning no rebalance was requested
-                    // and there was an attempt to finalize deletion
-                    return transformer == null ? ctx.result.withFlag(logicallyDeleted) : ctx.result.withValue(v);
-                }
-                continue;
-            }
-
-            // AT THIS POINT Key was found (key and value not valid) and context is updated
-            if (logicallyDeleted) {
-                // This is the case where we logically deleted this entry (marked the value off-heap as deleted),
-                // but someone helped and (marked the value reference as deleted) and reused the entry
-                // before we marked the value reference as deleted. We have the previous value saved in v.
-                return transformer == null ? ctx.result.withFlag(ValueUtils.ValueResult.TRUE) : ctx.result.withValue(v);
-            } else {
-                Result removeResult = config.valueOperator.remove(ctx, oldValue, transformer);
-                if (removeResult.operationResult == ValueUtils.ValueResult.FALSE) {
-                    // we didn't succeed to remove the value: it didn't contain oldValue, or was already marked
-                    // as deleted by someone else)
-                    return ctx.result.withFlag(ValueUtils.ValueResult.FALSE);
-                } else if (removeResult.operationResult == ValueUtils.ValueResult.RETRY) {
-                    continue;
-                }
-                // we have marked this value as deleted (successful remove)
-                logicallyDeleted = true;
-                v = (V) removeResult.value;
-            }
-
-            // AT THIS POINT value was marked deleted off-heap by this thread,
-            // continue to set the entry's value reference as deleted
-            assert ctx.entryIndex != EntryArray.INVALID_ENTRY_INDEX;
-            assert ctx.isValueValid();
-            ctx.entryState = EntryArray.EntryState.DELETED_NOT_FINALIZED;
-
-            if (inTheMiddleOfRebalance(c)) {
-                continue;
-            }
-
-            // If finalize deletion returns true, meaning rebalance was done and there was NO
-            // attempt to finalize deletion. There is going the help anyway, by next rebalance
-            // or updater. Thus it is OK not to restart, the linearization point of logical deletion
-            // is owned by this thread anyway and old value is kept in v.
-            finalizeDeletion(c, ctx); // includes publish/unpublish
-            return transformer == null ?
-                ctx.result.withFlag(ValueUtils.ValueResult.TRUE) : ctx.result.withValue(v);
-        }
-
-        throw new RuntimeException("remove failed: reached retry limit (1024).");
-    }
 
     private ThreadContext keyLookUp(K key) {
 
@@ -272,7 +200,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         }
         ThreadContext ctx = getThreadContext();
         // find chunk matching key, puts this key hash into ctx.operationKeyHash
-        HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+        HashChunk<K, V> c = findChunk(key, ctx);
         c.lookUpForGetOnly(ctx, key);
         if (!ctx.isValueValid()) {
             return null;
@@ -281,7 +209,12 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
     }
 
     // the zero-copy version of get
+    @Override
     OakUnscopedBuffer get(K key) {
+        if (key == null) {
+            throw new NullPointerException();
+        }
+
         ThreadContext ctx = keyLookUp(key);
         if (ctx == null) {
             return null;
@@ -297,13 +230,8 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         return transformer.apply(ctx.key);
     }
 
-
-    //private <T> T getValueTransformation(OakScopedReadBuffer key, OakTransformer<T> transformer) {
-    //    K deserializedKey = getKeySerializer().deserialize(key);
-    //    return getValueTransformation(deserializedKey, transformer);
-    //}
-
     // the non-ZC variation of the get
+    @Override
     <T> T getValueTransformation(K key, OakTransformer<T> transformer) {
         if (key == null || transformer == null) {
             throw new NullPointerException();
@@ -313,11 +241,12 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
         for (int i = 0; i < MAX_RETRIES; i++) {
             // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+            HashChunk<K, V> c = findChunk(key, ctx);
             c.lookUpForGetOnly(ctx, key);
             if (!ctx.isValueValid()) {
                 return null;
             }
+
 
             Result res = config.valueOperator.transform(ctx.result, ctx.value, transformer);
             if (res.operationResult == ValueUtils.ValueResult.RETRY) {
@@ -329,28 +258,9 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         throw new RuntimeException("getValueTransformation failed: reached retry limit (1024).");
     }
 
-    V replace(K key, V value, OakTransformer<V> valueDeserializeTransformer) {
-        ThreadContext ctx = getThreadContext();
-
-        for (int i = 0; i < MAX_RETRIES; i++) {
-            // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> chunk = hashArray.findChunk(calculateKeyHash(key, ctx));
-            chunk.lookUp(ctx, key);
-            if (!ctx.isValueValid()) {
-                return null;
-            }
-
-            // will return null if the value is deleted
-            Result result = config.valueOperator.exchange(chunk, ctx, value,
-                    valueDeserializeTransformer, getValueSerializer());
-            if (result.operationResult != ValueUtils.ValueResult.RETRY) {
-                return (V) result.value;
-            }
-            // it might be that this chunk is proceeding with rebalance -> help
-            helpRebalanceIfInProgress(chunk);
-        }
-
-        throw new RuntimeException("replace failed: reached retry limit (1024).");
+    @Override
+    protected HashChunk<K, V> findChunk(K key, ThreadContext ctx) {
+        return hashArray.findChunk(calculateKeyHash(key, ctx));
     }
 
     boolean replace(K key, V oldValue, V newValue, OakTransformer<V> valueDeserializeTransformer) {
@@ -358,7 +268,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
         for (int i = 0; i < MAX_RETRIES; i++) {
             // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+            BasicChunk<K, V> c = findChunk(key, ctx);
             c.lookUp(ctx, key);
             if (!ctx.isValueValid()) {
                 return false;
@@ -377,8 +287,9 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         throw new RuntimeException("replace failed: reached retry limit (1024).");
     }
 
-    // put the value assosiated with the key, only if key didn't exist
+    // put the value associated with the key, only if key didn't exist
     // returned results describes whether the value was inserted or not
+    @Override
     Result putIfAbsent(K key, V value, OakTransformer<V> transformer) {
         if (key == null || value == null) {
             throw new NullPointerException();
@@ -388,7 +299,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
         for (int i = 0; i < MAX_RETRIES; i++) {
             // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+            HashChunk<K, V> c = findChunk(key, ctx);
             c.lookUp(ctx, key);
 
             // If exists a matching value reference for the given key, and it isn't marked deleted,
@@ -397,6 +308,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
                 if (transformer == null) {
                     return ctx.result.withFlag(ValueUtils.ValueResult.FALSE);
                 }
+
                 Result res = config.valueOperator.transform(ctx.result, ctx.value, transformer);
                 if (res.operationResult == ValueUtils.ValueResult.TRUE) {
                     return res;
@@ -426,39 +338,11 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         throw new RuntimeException("putIfAbsent failed: reached retry limit (1024).");
     }
 
-    // if key with a valid value exists in the map, apply compute function on the value
-    // return true if compute did happen
-    boolean computeIfPresent(K key, Consumer<OakScopedWriteBuffer> computer) {
-        if (key == null || computer == null) {
-            throw new NullPointerException();
-        }
-
-        ThreadContext ctx = getThreadContext();
-
-        for (int i = 0; i < MAX_RETRIES; i++) {
-            // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
-            c.lookUp(ctx, key);
-
-            if (ctx.isValueValid()) {
-                ValueUtils.ValueResult res = config.valueOperator.compute(ctx.value, computer);
-                if (res == ValueUtils.ValueResult.TRUE) {
-                    // compute was successful and the value wasn't found deleted; in case
-                    // this value was already marked as deleted, continue to construct another slice
-                    return true;
-                } else if (res == ValueUtils.ValueResult.RETRY) {
-                    continue;
-                }
-            }
-            return false;
-        }
-
-        throw new RuntimeException("computeIfPresent failed: reached retry limit (1024).");
-    }
 
     // if key didn't exist, put the value to be associated with the key
     // otherwise perform compute on the existing value
     // return false if compute happened, true if put happened
+    @Override
     boolean putIfAbsentComputeIfPresent(K key, V value, Consumer<OakScopedWriteBuffer> computer) {
         if (key == null || value == null || computer == null) {
             throw new NullPointerException();
@@ -473,12 +357,13 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
             }
 
             // find chunk matching key, puts this key hash into ctx.operationKeyHash
-            HashChunk<K, V> c = hashArray.findChunk(calculateKeyHash(key, ctx));
+            HashChunk<K, V> c = findChunk(key, ctx);
             c.lookUp(ctx, key);
 
             // If there is a matching value reference for the given key, and it is not marked as deleted,
             // then apply compute on the existing value
             if (ctx.isValueValid()) {
+
                 ValueUtils.ValueResult res = config.valueOperator.compute(ctx.value, computer);
                 if (res == ValueUtils.ValueResult.TRUE) {
                     // compute was successful and the value wasn't found deleted; in case
@@ -521,6 +406,9 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
     private static final class IteratorState<K, V> extends BasicIteratorState<K, V> {
 
+        // lastKeyAccessed is used to find the index of the last chunk accessed
+        // but calculating the key hash and extracting the MSBs.
+        //keyBufferValid is used to check the validity of lastKeyAccessed field
         private KeyBuffer lastKeyAccessed = null;
         private boolean keyBufferValid = false;
 
@@ -545,6 +433,14 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
             this.keyBufferValid = keyBufferValid;
         }
 
+        @Override
+        public void copyState(BasicIteratorState<K, V> other) {
+            super.copyState(other);
+            lastKeyAccessed = ((IteratorState<K, V>) other).lastKeyAccessed;
+            keyBufferValid = ((IteratorState<K, V>) other).keyBufferValid;
+
+        }
+
         static <K, V> InternalOakHash.IteratorState<K, V> newInstance(
                 HashChunk<K, V> nextHashChunk, HashChunk<K, V>.HashChunkIter nextChunkIter) {
 
@@ -565,7 +461,6 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
         protected void initAfterRebalance() {
             //TODO - refactor to use OakReadBuffer without deserializing.
             getState().getChunk().readKeyFromEntryIndex(ctx.tempKey, getState().getIndex());
-            K nextKey = getKeySerializer().deserialize(ctx.tempKey);
 
 
             // Update the state to point to last returned key.
@@ -602,8 +497,8 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
                 chunk.readKey(ctx);
 
-                ((IteratorState) getState()).setKeyBuffer(ctx.key);
-                ((IteratorState) getState()).setKeyValid(ctx.isKeyValid());
+                ((IteratorState<K, V>) getState()).setKeyBuffer(ctx.key);
+                ((IteratorState<K, V>) getState()).setKeyValid(ctx.isKeyValid());
                 validState = ctx.isKeyValid();
 
                 if (validState & needsValue) {
@@ -643,8 +538,8 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
                 if (key != null) {
                     validState = c.readKeyFromEntryIndex(key.getInternalScopedReadBuffer(), curIndex);
-                    ((IteratorState) getState()).setKeyBuffer(key.getInternalScopedReadBuffer());
-                    ((IteratorState) getState()).setKeyValid(validState);
+                    ((IteratorState<K, V>) getState()).setKeyBuffer(key.getInternalScopedReadBuffer());
+                    ((IteratorState<K, V>) getState()).setKeyValid(validState);
 
                     assert validState;
                 }
@@ -675,19 +570,22 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
             //Init state, not valid yet, must move forward
             setState(InternalOakHash.IteratorState.newInstance(nextHashChunk, nextChunkIter));
-            ((IteratorState) getState()).setKeyValid(false);
+            setPrevState(InternalOakHash.IteratorState.newInstance(null, null));
+            ((IteratorState<K, V>) getState()).setKeyValid(false);
             advanceState();
         }
 
         @Override
         protected BasicChunk<K, V> getNextChunk(BasicChunk<K, V> current) {
-            KeyBuffer keyBuffer = ((IteratorState) getState()).getKeyBuffer();
+            KeyBuffer keyBuffer = ((IteratorState<K, V>) getState()).getKeyBuffer();
             int lastKeyHash = 0;
+
             boolean hashValid;
             if (keyBuffer == null) {
                 hashValid = false;
             } else {
-                K deserializedKey = getKeySerializer().deserialize(ctx.key);
+                K deserializedKey = getKeySerializer().deserialize(keyBuffer);
+
 
                 lastKeyHash = calculateKeyHash(deserializedKey, ctx);
                 hashValid = true;
@@ -695,29 +593,8 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
             return hashArray.getNextChunk(current, lastKeyHash, hashValid);
         }
 
-        @Override
-        protected void advanceState() {
-
-            HashChunk<K, V> hashChunk = (HashChunk<K, V>) getState().getChunk();
-            BasicChunk.BasicChunkIter chunkIter = getState().getChunkIter();
-
-
-            while (!chunkIter.hasNext()) { // chunks can have only removed keys
-                hashChunk = (HashChunk<K, V>) getNextChunk(hashChunk);
-                if (hashChunk == null) {
-                    //End of iteration
-                    setState(null);
-                    return;
-                }
-                chunkIter = getChunkIter(hashChunk);
-            }
-
-            int nextIndex = chunkIter.next(ctx);
-            getState().set(hashChunk, chunkIter, nextIndex);
-        }
-
-        protected HashChunk<K, V>.HashChunkIter getChunkIter(HashChunk<K, V> current) {
-            return current.chunkIter(ctx);
+        protected BasicChunk.BasicChunkIter getChunkIter(BasicChunk<K, V> current) {
+            return ((HashChunk<K, V>) current).chunkIter(ctx);
         }
     }
 
@@ -752,6 +629,7 @@ class InternalOakHash<K, V> extends InternalOakBasics<K, V> {
 
         public T next() {
             advance(true);
+
             Result res = config.valueOperator.transform(ctx.result, ctx.value, transformer);
             // If this value is deleted, try the next one
             if (res.operationResult == ValueUtils.ValueResult.FALSE) {

--- a/core/src/main/java/com/yahoo/oak/OakMap.java
+++ b/core/src/main/java/com/yahoo/oak/OakMap.java
@@ -47,7 +47,6 @@ public class OakMap<K, V> extends AbstractMap<K, V>
         final OakSharedConfig<K, V> config = internalOakMap.config;
 
         this.internalOakMap = internalOakMap;
-
         this.fromKey = fromKey;
         this.fromInclusive = fromInclusive;
         this.toKey = toKey;

--- a/core/src/main/java/com/yahoo/oak/ThreadContext.java
+++ b/core/src/main/java/com/yahoo/oak/ThreadContext.java
@@ -6,9 +6,6 @@
 
 package com.yahoo.oak;
 
-/**
- * Encapsulates a context, from when a key/value/entry operation has begun until it was completed
- */
 class ThreadContext {
 
     /*-----------------------------------------------------------

--- a/core/src/main/java/com/yahoo/oak/ThreadIndexCalculator.java
+++ b/core/src/main/java/com/yahoo/oak/ThreadIndexCalculator.java
@@ -33,7 +33,8 @@ final class ThreadIndexCalculator {
             }
             currentIndex = (currentIndex + 1) % MAX_THREADS;
             iterationCnt++;
-            assert iterationCnt < MAX_THREADS;
+            assert (iterationCnt < MAX_THREADS) : (String.format("threadID: %s, currentIndex: %s, iterationCnt: %s",
+                    threadID, currentIndex, iterationCnt));
         }
         return currentIndex;
     }

--- a/core/src/test/java/com/yahoo/oak/FirstLevelHashArrayTest.java
+++ b/core/src/test/java/com/yahoo/oak/FirstLevelHashArrayTest.java
@@ -7,7 +7,6 @@
 
 package com.yahoo.oak;
 
-
 import com.yahoo.oak.common.OakCommonBuildersFactory;
 import org.junit.After;
 import org.junit.Assert;

--- a/core/src/test/java/com/yahoo/oak/MultiThreadTestHash.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadTestHash.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2020, Verizon Media.
+ * Licensed under the terms of the Apache 2.0 license.
+ * Please see LICENSE file in the project root for terms.
+ */
+
+package com.yahoo.oak;
+
+import com.yahoo.oak.common.OakCommonBuildersFactory;
+import com.yahoo.oak.test_utils.ExecutorUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.function.Consumer;
+
+public class MultiThreadTestHash {
+
+
+    private static final int NUM_THREADS = 31;
+    private static final long TIME_LIMIT_IN_SECONDS = 80;
+
+    private static final int MAX_ITEMS_PER_CHUNK = 2048;
+
+    private OakHashMap<Integer, Integer> oak;
+    private ExecutorUtils<Void> executor;
+
+    private CountDownLatch latch;
+
+    private final int threadRangeWidth = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK);
+    private final int halfRangeWidth = threadRangeWidth / 2;
+    private final int globalWriteRangeStart = (int) Math.round(0.5 * MAX_ITEMS_PER_CHUNK);
+    private final int globalWriteRangeEnd = globalWriteRangeStart + NUM_THREADS * threadRangeWidth;
+
+    @Before
+    public void init() {
+        OakMapBuilder<Integer, Integer> builder = OakCommonBuildersFactory.getDefaultIntBuilder()
+                .setChunkMaxItems(MAX_ITEMS_PER_CHUNK);
+        oak = builder.buildHashMap();
+
+        latch = new CountDownLatch(1);
+        executor = new ExecutorUtils<>(NUM_THREADS);
+    }
+
+    @After
+    public void finish() {
+        executor.shutdownNow();
+        oak.close();
+    }
+
+
+    class RunThreads implements Callable<Void> {
+        CountDownLatch latch;
+        Integer internalId;
+
+        RunThreads(CountDownLatch latch, int id) {
+            this.internalId = id;
+            this.latch = latch;
+        }
+
+        @Override
+        public Void call() throws InterruptedException {
+            latch.await();
+            Integer value;
+
+            int myRangeStart = internalId * threadRangeWidth + globalWriteRangeStart;
+            int myRangeEnd = myRangeStart + threadRangeWidth;
+
+            for (int i = 0; i < globalWriteRangeStart; i++) {
+                value = oak.get(i);
+                Assert.assertNull(value);
+            }
+            for (int i = myRangeStart; i < myRangeStart + halfRangeWidth; i++) {
+                oak.zc().putIfAbsent(i, i);
+            }
+            for (Integer i = globalWriteRangeStart; i < globalWriteRangeEnd; i++) {
+                value = oak.get(i);
+                if (i >= myRangeStart && i < myRangeStart + halfRangeWidth) {
+                    Assert.assertEquals(i, value);
+                }
+                if (value != null) {
+                    Assert.assertEquals(i, value);
+                }
+            }
+            for (int i = 0; i < globalWriteRangeStart; i++) {
+                value = oak.get(i);
+                Assert.assertNull(value);
+            }
+            for (int i = myRangeStart + halfRangeWidth; i < myRangeEnd; i++) {
+                oak.zc().putIfAbsent(i, i);
+            }
+            for (int i = myRangeStart + halfRangeWidth; i < myRangeEnd; i++) {
+                oak.zc().remove(i);
+            }
+            for (Integer i = globalWriteRangeStart; i < globalWriteRangeEnd; i++) {
+                value = oak.get(i);
+                if (i >= myRangeStart && i < myRangeStart + halfRangeWidth) {
+                    Assert.assertEquals(i, value);
+                } else if (i >= myRangeStart + halfRangeWidth && i < myRangeStart ) {
+                    Assert.assertNull(value);
+                } else if (value != null) {
+                    Assert.assertEquals(i, value);
+                }
+
+            }
+            for (int i = myRangeStart + halfRangeWidth; i < myRangeEnd; i++) {
+                oak.zc().putIfAbsent(i, i);
+            }
+
+            for (Integer i = globalWriteRangeStart; i < globalWriteRangeEnd; i++) {
+                value = oak.get(i);
+                if (i >= myRangeStart && i < myRangeEnd) {
+                    Assert.assertEquals(i, value);
+                } else if (value != null) {
+                    Assert.assertEquals(i, value);
+                }
+
+            }
+
+            for (int i = 0; i < globalWriteRangeStart; i++) {
+                value = oak.get(i);
+                Assert.assertNull(value);
+            }
+            for (int i = myRangeStart + halfRangeWidth; i < myRangeEnd; i++) {
+                oak.zc().remove(i);
+            }
+
+            Iterator<Integer> valIter = oak.values().iterator();
+            boolean[] valuesPresent = new boolean[threadRangeWidth];
+
+            while (valIter.hasNext() ) {
+                Integer nxtValue = valIter.next();
+
+                if (nxtValue >= myRangeStart && nxtValue < myRangeEnd) {
+                    int idxFixed = nxtValue - myRangeStart;
+
+                    Assert.assertFalse("thread ID " + internalId + " value " + nxtValue, valuesPresent[idxFixed]);
+                    valuesPresent[idxFixed] = true;
+                }
+            }
+
+            for (int idx = 0; idx < valuesPresent.length; idx ++) {
+                if (idx < halfRangeWidth) {
+                    Assert.assertTrue(valuesPresent[idx]);
+                } else {
+                    Assert.assertFalse(valuesPresent[idx]);
+                }
+            }
+
+
+            for (int i = myRangeStart; i < myRangeEnd; i++) {
+                ByteBuffer bb = ByteBuffer.allocate(4);
+                bb.putInt(i);
+                bb.flip();
+                ByteBuffer bb1 = ByteBuffer.allocate(4);
+                bb1.putInt(i + 1);
+                bb1.flip();
+                oak.zc().putIfAbsent(i, i );
+            }
+            return null;
+        }
+    }
+
+    @Test
+    public void testThreads() throws ExecutorUtils.ExecutionError {
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTestHash.RunThreads(latch, i));
+        latch.countDown();
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
+
+        for (int i = 0; i < globalWriteRangeStart; i++) {
+            Integer value = oak.get(i);
+            Assert.assertNull(value);
+        }
+        for (int i = globalWriteRangeStart; i < globalWriteRangeEnd; i++) {
+            Integer value = oak.get(i);
+            Assert.assertEquals(i, value.intValue());
+        }
+    }
+
+    class RunThreadsDescend implements Callable<Void> {
+        CountDownLatch latch;
+        CyclicBarrier barrier;
+        int internalId;
+
+        RunThreadsDescend(CountDownLatch latch, CyclicBarrier barrier, int id) {
+            this.latch = latch;
+            this.barrier = barrier;
+            this.internalId = id;
+        }
+
+        @Override
+        public Void call() throws BrokenBarrierException, InterruptedException {
+            latch.await();
+            Integer i;
+            Integer value;
+            Iterator<Integer> iter;
+
+            int myRangeStart = internalId * threadRangeWidth + globalWriteRangeStart;
+            int myRangeEnd = myRangeStart + threadRangeWidth;
+
+
+            for (i = myRangeStart; i < myRangeEnd; i++) {
+                oak.zc().putIfAbsent(i, i);
+                value = oak.get(i);
+                Assert.assertEquals(i, value);
+            }
+
+
+
+            barrier.await();
+
+            for (i = myRangeStart + halfRangeWidth; i < myRangeEnd; i++) {
+                oak.zc().remove(i);
+            }
+            iter = oak.values().iterator();
+            i = 0;
+            while (iter.hasNext()) {
+                iter.next();
+                i++;
+            }
+            int expectedNumberOfEntries = halfRangeWidth * NUM_THREADS;
+            Assert.assertTrue(i >= expectedNumberOfEntries);
+
+            Consumer<OakScopedWriteBuffer> computer = oakWBuffer -> {
+                if (oakWBuffer.getInt(0) % 4 ==  0) {
+                    oakWBuffer.putInt(0, 1);
+                }
+            };
+
+            for (i = myRangeStart; i < myRangeStart + halfRangeWidth; i++) {
+                oak.zc().computeIfPresent(i, computer);
+            }
+
+            barrier.await();
+
+            for (i = myRangeStart; i < myRangeStart + halfRangeWidth; i++) {
+                oak.zc().remove(i);
+            }
+
+
+            for (i = myRangeStart; i < myRangeEnd; i++) {
+                oak.zc().putIfAbsent(i, i);
+            }
+
+            for (i = myRangeStart; i < myRangeEnd; i++) {
+                oak.zc().computeIfPresent(i, computer);
+            }
+
+            return null;
+        }
+    }
+
+    @Test
+    public void testThreadsDescend() throws ExecutorUtils.ExecutionError {
+        CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
+
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTestHash.RunThreadsDescend(latch, barrier, i));
+        latch.countDown();
+        executor.shutdown(TIME_LIMIT_IN_SECONDS);
+
+        for (Integer i = globalWriteRangeStart; i < globalWriteRangeEnd; i++) {
+            Integer value = oak.get(i);
+            if (i % 4 == 0) {
+                Assert.assertEquals(1, value.intValue());
+            } else {
+                Assert.assertEquals(i, value);
+            }
+        }
+    }
+
+}

--- a/core/src/test/java/com/yahoo/oak/MultiThreadTestMap.java
+++ b/core/src/test/java/com/yahoo/oak/MultiThreadTestMap.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.function.Consumer;
 
-public class MultiThreadTest {
+public class MultiThreadTestMap {
 
     private static final int NUM_THREADS = 31;
     private static final long TIME_LIMIT_IN_SECONDS = 80;
@@ -156,7 +156,7 @@ public class MultiThreadTest {
 
     @Test
     public void testThreads() throws ExecutorUtils.ExecutionError {
-        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreads(latch));
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTestMap.RunThreads(latch));
         latch.countDown();
         executor.shutdown(TIME_LIMIT_IN_SECONDS);
 
@@ -278,7 +278,7 @@ public class MultiThreadTest {
     public void testThreadsDescend() throws ExecutorUtils.ExecutionError {
         CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS);
 
-        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTest.RunThreadsDescend(latch, barrier));
+        executor.submitTasks(NUM_THREADS, i -> new MultiThreadTestMap.RunThreadsDescend(latch, barrier));
         latch.countDown();
         executor.shutdown(TIME_LIMIT_IN_SECONDS);
 

--- a/core/src/test/java/com/yahoo/oak/ParametrizedMapApiTest.java
+++ b/core/src/test/java/com/yahoo/oak/ParametrizedMapApiTest.java
@@ -199,6 +199,7 @@ public class ParametrizedMapApiTest {
 
     @Test
     public void keySet() {
+
         int numKeys = 10;
         for (int i = 0; i < numKeys; i++) {
             oak.put(i, i);
@@ -213,7 +214,8 @@ public class ParametrizedMapApiTest {
 
     @Test
     public void iterTest() {
-        boolean testingHash;
+        boolean testingHash = false;
+
         if (oak instanceof OakHashMap) {
             testingHash = true;
         } else {
@@ -242,6 +244,8 @@ public class ParametrizedMapApiTest {
                 expected++;
             }
         }
+
+
     }
 
     @Test

--- a/core/src/test/java/com/yahoo/oak/SingleThreadIteratorTestHash.java
+++ b/core/src/test/java/com/yahoo/oak/SingleThreadIteratorTestHash.java
@@ -21,8 +21,7 @@ import java.util.Map;
 public class SingleThreadIteratorTestHash {
 
     private OakHashMap<Integer, Integer> oak;
-    private int maxItemsPerChunk = 2048;
-    private int iteratorsRange = 10;
+    private final int maxItemsPerChunk = 2048;
 
     @Before
     public void init() {
@@ -37,21 +36,33 @@ public class SingleThreadIteratorTestHash {
         BlocksPool.clear();
     }
 
-    @Test
-    public void testIterator() {
-        Integer value;
-
-        for (Integer i = 0; i < 2 * maxItemsPerChunk; i++) {
+    private void populate(int numOfItems) {
+        for (Integer i = 0; i < numOfItems; i++) {
             oak.zc().put(i, i);
         }
-        for (Integer i = 0; i < 2 * maxItemsPerChunk; i++) {
+    }
+
+    @Test
+    public void basicSanityCheck() {
+        Integer value;
+        int numOfItems = 2 * maxItemsPerChunk;
+        populate(numOfItems);
+
+        for (Integer i = 0; i < numOfItems; i++) {
             value = oak.get(i);
             Assert.assertEquals(i, value);
         }
+    }
+
+    @Test
+    public void testIterator() {
+        Integer value;
+        int numOfItems = 2 * maxItemsPerChunk;
+        populate(numOfItems);
 
         Iterator<Integer> valIter = oak.values().iterator();
         Iterator<Map.Entry<Integer, Integer>> entryIter = oak.entrySet().iterator();
-        boolean valuesPresent[] = new boolean[2 * maxItemsPerChunk];
+        boolean[] valuesPresent = new boolean[numOfItems];
         while (valIter.hasNext()) {
             Integer expectedVal = valIter.next();
             Assert.assertFalse(valuesPresent[expectedVal]);
@@ -66,15 +77,15 @@ public class SingleThreadIteratorTestHash {
         }
 
 
-        for (Integer i = 0; i < maxItemsPerChunk; i++) {
+        for (int i = 0; i < numOfItems / 2; i++) {
             oak.zc().remove(i);
         }
-        for (Integer i = 0; i < maxItemsPerChunk; i++) {
+        for (int i = 0; i < numOfItems / 2; i++) {
             value = oak.get(i);
             Assert.assertNull(value);
         }
 
-        for (Integer i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
+        for (Integer i = numOfItems / 2; i < numOfItems; i++) {
             value = oak.get(i);
             Assert.assertEquals(i, value);
         }
@@ -83,7 +94,7 @@ public class SingleThreadIteratorTestHash {
         valIter = oak.values().iterator();
         entryIter = oak.entrySet().iterator();
 
-        valuesPresent = new boolean[2 * maxItemsPerChunk];
+        valuesPresent = new boolean[numOfItems];
         while (valIter.hasNext()) {
             Integer expectedVal = valIter.next();
             Assert.assertFalse(valuesPresent[expectedVal]);
@@ -92,26 +103,26 @@ public class SingleThreadIteratorTestHash {
             Map.Entry<Integer, Integer> e = entryIter.next();
             Assert.assertEquals(expectedVal, e.getValue());
         }
-        for (int index = 0; index < 2 * maxItemsPerChunk; index++) {
-            if ( index < maxItemsPerChunk) {
+        for (int index = 0; index < numOfItems; index++) {
+            if ( index < numOfItems / 2) {
                 Assert.assertFalse(valuesPresent[index]);
             } else {
                 Assert.assertTrue(valuesPresent[index]);
             }
         }
-        for (Integer i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
+        for (int i = numOfItems / 2; i < numOfItems; i++) {
             oak.zc().remove(i);
         }
-        for (Integer i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
+        for (int i = numOfItems / 2; i < numOfItems; i++) {
             value = oak.get(i);
             Assert.assertNull(value);
         }
-        for (Integer i = 0; i < 2 * maxItemsPerChunk; i++) {
+        for (Integer i = 0; i < numOfItems; i++) {
             oak.zc().put(i, i);
         }
 
 
-        for (Integer i = 1; i < (2 * maxItemsPerChunk - 1); i++) {
+        for (int i = 1; i < (numOfItems - 1); i++) {
             oak.zc().remove(i);
         }
 
@@ -119,7 +130,7 @@ public class SingleThreadIteratorTestHash {
         value = oak.get(expectedVal);
         Assert.assertEquals(expectedVal, value);
 
-        expectedVal = 2 * maxItemsPerChunk - 1;
+        expectedVal = numOfItems - 1;
         value = oak.get(expectedVal);
         Assert.assertEquals(expectedVal, value);
 
@@ -127,6 +138,231 @@ public class SingleThreadIteratorTestHash {
         Assert.assertTrue(valIter.hasNext());
         Assert.assertEquals((Integer) 0, valIter.next());
         Assert.assertTrue(valIter.hasNext());
-        Assert.assertEquals((Integer) (2 * maxItemsPerChunk - 1), valIter.next());
+        Assert.assertEquals((Integer) (numOfItems - 1), valIter.next());
+    }
+
+    /**
+     * Test for stream iterators. The test goes over the hash with three stream iterators in parallel
+     * and verifies all is correct
+     */
+    @Test
+    public void testStreamIterator() {
+        int numOfItems = 2 * maxItemsPerChunk;
+        populate(numOfItems);
+
+        Iterator<OakUnscopedBuffer> keyStreamIterator = oak.zc().keyStreamSet().iterator();
+        Iterator<OakUnscopedBuffer> valStreamIterator = oak.zc().valuesStream().iterator();
+        Iterator<Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer>> entryStreamIterator
+                = oak.zc().entryStreamSet().iterator();
+
+        boolean[] valuesPresent = new boolean[numOfItems];
+
+        while (keyStreamIterator.hasNext()) {
+            Integer expectedKey = keyStreamIterator.next()
+                    .transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+            Integer expectedVal = valStreamIterator.next()
+                    .transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+            Assert.assertFalse(valuesPresent[expectedKey]);
+            Assert.assertEquals(expectedKey, expectedVal);
+
+            Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer> e = entryStreamIterator.next();
+            Integer entryKey = e.getKey().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+            Integer entryVal = e.getValue().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+            Assert.assertFalse(valuesPresent[entryKey]);
+            Assert.assertEquals(entryKey, entryVal);
+
+            valuesPresent[expectedVal] = true;
+
+        }
+        for (boolean flag:valuesPresent) {
+            Assert.assertTrue(flag);
+        }
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        int numOfItems = 2 * maxItemsPerChunk;
+
+        int valToRemove1 = 10;
+        int valToRemove2 = 20;
+
+        populate(numOfItems);
+
+        Iterator<Integer> valIter = oak.values().iterator();
+        Iterator<Map.Entry<Integer, Integer>> entryIter = oak.entrySet().iterator();
+        boolean[] valuesPresent = new boolean[numOfItems];
+        while (valIter.hasNext()) {
+            Integer expectedVal = valIter.next();
+            Assert.assertFalse(valuesPresent[expectedVal]);
+            valuesPresent[expectedVal] = true;
+
+            Map.Entry<Integer, Integer> e = entryIter.next();
+
+            if (expectedVal.equals(valToRemove1)) {
+                valIter.remove();
+            }
+            if (expectedVal.equals(valToRemove2)) {
+                entryIter.remove();
+            }
+
+            Assert.assertEquals(expectedVal, e.getKey());
+            Assert.assertEquals(expectedVal, e.getValue());
+        }
+        for (boolean flag : valuesPresent) {
+            Assert.assertTrue(flag);
+        }
+
+
+        // iterate over the remaining entries
+        valIter = oak.values().iterator();
+        entryIter = oak.entrySet().iterator();
+        valuesPresent = new boolean[numOfItems];
+        while (valIter.hasNext()) {
+            Integer expectedVal = valIter.next();
+            Assert.assertFalse(valuesPresent[expectedVal]);
+            valuesPresent[expectedVal] = true;
+
+            Map.Entry<Integer, Integer> e = entryIter.next();
+
+            Assert.assertEquals(expectedVal, e.getKey());
+            Assert.assertEquals(expectedVal, e.getValue());
+        }
+
+        for (int idx = 0; idx < valuesPresent.length; idx++) {
+            if (idx == valToRemove1 || idx == valToRemove2) {
+                Assert.assertFalse(valuesPresent[idx]);
+            } else {
+                Assert.assertTrue(valuesPresent[idx]);
+            }
+        }
+    }
+
+    @Test
+    public void testStreamIteratorsRemove() {
+        int numOfItems = 2 * maxItemsPerChunk;
+
+        int valToRemove1 = numOfItems / 4;
+        int valToRemove2 = numOfItems / 2;
+
+
+        populate(numOfItems);
+
+
+        Iterator<OakUnscopedBuffer> keyStreamIterator = oak.zc().keyStreamSet().iterator();
+
+        while (keyStreamIterator.hasNext()) {
+            Integer currKey = keyStreamIterator.next()
+                    .transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+
+            if (currKey.equals(valToRemove1) || currKey.equals(valToRemove2)) {
+                keyStreamIterator.remove();
+            }
+        }
+
+        // iterate over the remaining entries
+
+        Iterator<Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer>> entryStreamIterator
+                = oak.zc().entryStreamSet().iterator();
+
+        boolean[] valuesPresent = new boolean[numOfItems];
+
+        while (entryStreamIterator.hasNext()) {
+
+            Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer> e = entryStreamIterator.next();
+            Integer entryKey = e.getKey().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+            Integer entryVal = e.getValue().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+            Assert.assertEquals(entryKey, entryVal);
+            Assert.assertFalse(valuesPresent[entryKey]);
+            valuesPresent[entryKey] = true;
+
+        }
+
+        for (int idx = 0; idx < valuesPresent.length; idx++) {
+            if (idx == valToRemove1 || idx == valToRemove2) {
+                Assert.assertFalse(valuesPresent[idx]);
+            } else {
+                Assert.assertTrue(valuesPresent[idx]);
+            }
+        }
+    }
+    @Test
+    public void testIteratorRemoveCorners() {
+
+        int numOfItems = 200;
+        int valueToRemove1 = 50;
+        int valueToRemove2 = 100;
+
+        populate(numOfItems);
+        Iterator<Integer> valIter = oak.values().iterator();
+        while (valIter.hasNext()) {
+            Integer expectedVal = valIter.next();
+            if (expectedVal.equals(valueToRemove1)) {
+                oak.remove(expectedVal);
+
+                valIter.remove();
+            }
+        }
+
+        valIter = oak.values().iterator();
+        boolean[] valuesMet = new boolean[numOfItems];
+        while (valIter.hasNext()) {
+            valuesMet[valIter.next()] = true;
+        }
+        for (int idx = 0; idx < valuesMet.length; idx ++) {
+            if (idx != valueToRemove1) {
+                Assert.assertTrue(valuesMet[idx]);
+            } else {
+                Assert.assertFalse(valuesMet[idx]);
+            }
+        }
+
+        // Two iterators running in parallel, the first removes the entry
+        // the second is expected to return with next()
+
+        Iterator<Integer> valIter1 = oak.values().iterator();
+        Iterator<Integer> valIter2 = oak.values().iterator();
+        valuesMet = new boolean[numOfItems];
+        while (valIter1.hasNext()) {
+            Integer expectedVal = valIter1.next();
+            if (expectedVal.equals(valueToRemove2)) {
+                valIter1.remove();
+            }
+            if (valIter1.hasNext()) {
+                valuesMet[valIter2.next()] = true;
+            }
+        }
+        for (int idx = 0; idx < valuesMet.length; idx ++) {
+            if (idx != valueToRemove1 &&  idx != valueToRemove2) {
+                Assert.assertTrue(valuesMet[idx]);
+            } else {
+                Assert.assertFalse(valuesMet[idx]);
+            }
+        }
+    }
+
+    /**
+     * check how the iterator handles empty and sparse chunks
+     */
+    @Test
+    public void testSparsePopulation() {
+        int numOfItems = 10;
+        populate(numOfItems);
+
+        Iterator<Integer> valIter = oak.values().iterator();
+
+        boolean[] valuesPresent = new boolean[numOfItems];
+        while (valIter.hasNext()) {
+            Integer expectedVal = valIter.next();
+            Assert.assertFalse(valuesPresent[expectedVal]);
+            valuesPresent[expectedVal] = true;
+
+        }
+        for (boolean flag:valuesPresent) {
+            Assert.assertTrue(flag);
+        }
     }
 }

--- a/core/src/test/java/com/yahoo/oak/SingleThreadIteratorTestMap.java
+++ b/core/src/test/java/com/yahoo/oak/SingleThreadIteratorTestMap.java
@@ -16,11 +16,11 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Map;
 
-public class SingleThreadIteratorTest {
+public class SingleThreadIteratorTestMap {
 
     private OakMap<Integer, Integer> oak;
-    private int maxItemsPerChunk = 2048;
-    private int iteratorsRange = 10;
+    private final int maxItemsPerChunk = 2048;
+    private final int iteratorsRange = 10;
 
     @Before
     public void init() {
@@ -56,10 +56,10 @@ public class SingleThreadIteratorTest {
             Assert.assertEquals(expectedVal, e.getValue());
             expectedVal++;
         }
-        for (Integer i = 0; i < maxItemsPerChunk; i++) {
+        for (int i = 0; i < maxItemsPerChunk; i++) {
             oak.zc().remove(i);
         }
-        for (Integer i = 0; i < maxItemsPerChunk; i++) {
+        for (int i = 0; i < maxItemsPerChunk; i++) {
             value = oak.get(i);
             Assert.assertNull(value);
         }
@@ -79,10 +79,10 @@ public class SingleThreadIteratorTest {
             Assert.assertEquals(expectedVal, e.getValue());
             expectedVal++;
         }
-        for (Integer i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
+        for (int i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
             oak.zc().remove(i);
         }
-        for (Integer i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
+        for (int i = maxItemsPerChunk; i < 2 * maxItemsPerChunk; i++) {
             value = oak.get(i);
             Assert.assertNull(value);
         }
@@ -91,7 +91,7 @@ public class SingleThreadIteratorTest {
         }
 
 
-        for (Integer i = 1; i < (2 * maxItemsPerChunk - 1); i++) {
+        for (int i = 1; i < (2 * maxItemsPerChunk - 1); i++) {
             oak.zc().remove(i);
         }
 
@@ -111,6 +111,41 @@ public class SingleThreadIteratorTest {
     }
 
     @Test
+    public void testStreamIterator() {
+        int numOfItems = 2 * maxItemsPerChunk;
+        populate(numOfItems);
+
+        Iterator<OakUnscopedBuffer> keyStreamIterator = oak.zc().keyStreamSet().iterator();
+        Iterator<OakUnscopedBuffer> valStreamIterator = oak.zc().valuesStream().iterator();
+        Iterator<Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer>> entryStreamIterator
+                = oak.zc().entryStreamSet().iterator();
+
+
+        Integer expectedVal = 0;
+        while (keyStreamIterator.hasNext()) {
+            Integer curKey = keyStreamIterator.next()
+                    .transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+            Integer curVal = valStreamIterator.next()
+                    .transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+            Assert.assertEquals(expectedVal, curVal);
+            Assert.assertEquals(curVal, curKey);
+
+            Map.Entry<OakUnscopedBuffer, OakUnscopedBuffer> e = entryStreamIterator.next();
+            Integer entryKey = e.getKey().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+            Integer entryVal = e.getValue().transform(OakCommonBuildersFactory.DEFAULT_INT_SERIALIZER::deserialize);
+
+            Assert.assertEquals(expectedVal, entryKey);
+            Assert.assertEquals(entryKey, entryVal);
+
+            expectedVal++;
+
+        }
+        Assert.assertEquals(expectedVal.intValue(), numOfItems );
+    }
+
+
+    @Test
     public void testGetRange() {
         try (OakMap<Integer, Integer> sub = oak.subMap(0, true, 3 * maxItemsPerChunk, false)) {
             Iterator<Integer> iter = sub.values().iterator();
@@ -127,24 +162,24 @@ public class SingleThreadIteratorTest {
 
 
             iter = sub.values().iterator();
-            Integer c = 0;
+            int c = 0;
             c = checkValues(iter, c);
-            Assert.assertEquals(3 * maxItemsPerChunk, c.intValue());
+            Assert.assertEquals(3 * maxItemsPerChunk, c);
 
         }
 
         try (OakMap<Integer, Integer> sub = oak.subMap(6 * maxItemsPerChunk, true, 9 * maxItemsPerChunk, false)) {
             Iterator<Integer> iter = sub.values().iterator();
-            Integer c = 6 * maxItemsPerChunk;
+            int c = 6 * maxItemsPerChunk;
             c = checkValues(iter, c);
-            Assert.assertEquals(9 * maxItemsPerChunk, c.intValue());
+            Assert.assertEquals(9 * maxItemsPerChunk, c);
         }
 
         try (OakMap<Integer, Integer> sub = oak.subMap(9 * maxItemsPerChunk, true, 13 * maxItemsPerChunk, false)) {
             Iterator<Integer> iter = sub.values().iterator();
-            Integer c = 9 * maxItemsPerChunk;
+            int c = 9 * maxItemsPerChunk;
             c = checkValues(iter, c);
-            Assert.assertEquals(12 * maxItemsPerChunk, c.intValue());
+            Assert.assertEquals(12 * maxItemsPerChunk, c);
         }
 
         try (OakMap<Integer, Integer> sub = oak.subMap(12 * maxItemsPerChunk, true, 13 * maxItemsPerChunk, false)) {
@@ -203,7 +238,7 @@ public class SingleThreadIteratorTest {
 
         try (OakMap<Integer, Integer> sub = oak.subMap(1, false, iteratorsRange - 1, true);
              OakMap<Integer, Integer> oakSubDesc = sub.descendingMap()) {
-            Iterator valIter = oakSubDesc.values().iterator();
+            Iterator<Integer> valIter = oakSubDesc.values().iterator();
             i = iteratorsRange;
             while (valIter.hasNext()) {
                 i--;
@@ -232,7 +267,7 @@ public class SingleThreadIteratorTest {
         // it is important to test different distribution of inserted keys, not only increasing
         try (OakMap<Integer, Integer> oakDesc = oak.descendingMap()) {
 
-            Iterator iter = oakDesc.values().iterator();
+            Iterator<Integer> iter = oakDesc.values().iterator();
             Assert.assertFalse(iter.hasNext());
 
             Integer i;
@@ -290,9 +325,7 @@ public class SingleThreadIteratorTest {
         }
         for (i = 0; i < 3 * maxItemsPerChunk; i++) {
             Integer value = oak.get(i);
-            if (value == null) {
-                assert false;
-            }
+            assert value != null;
             Assert.assertNotNull(value);
             Assert.assertEquals(i, value);
         }
@@ -321,7 +354,7 @@ public class SingleThreadIteratorTest {
     public void testDescending() {
         try (OakMap<Integer, Integer> oakDesc = oak.descendingMap()) {
 
-            Iterator iter = oakDesc.values().iterator();
+            Iterator<Integer> iter = oakDesc.values().iterator();
             Assert.assertFalse(iter.hasNext());
 
             Integer i;
@@ -486,4 +519,76 @@ public class SingleThreadIteratorTest {
 
     }
 
+    @Test
+    public void testIteratorRemove() {
+
+        Integer valToRemove1 = 2;
+        Integer valToRemove2 = 4;
+
+        for (Integer i = 0; i < 2 * maxItemsPerChunk; i++) {
+            oak.zc().put(i, i);
+        }
+
+        Iterator<Integer> valIter = oak.values().iterator();
+        Iterator<Map.Entry<Integer, Integer>> entryIter = oak.entrySet().iterator();
+        Integer expectedVal = 0;
+        while (valIter.hasNext()) {
+            Assert.assertEquals(expectedVal, valIter.next());
+            Map.Entry<Integer, Integer> e = entryIter.next();
+            Assert.assertEquals(expectedVal, e.getKey());
+            Assert.assertEquals(expectedVal, e.getValue());
+
+            if (expectedVal.equals(valToRemove1)) {
+                valIter.remove();
+            }
+            if (expectedVal.equals(valToRemove2)) {
+                entryIter.remove();
+            }
+
+            expectedVal++;
+        }
+
+        valIter = oak.values().iterator();
+        entryIter = oak.entrySet().iterator();
+        expectedVal = 0;
+
+        while (valIter.hasNext()) {
+            if (expectedVal.equals(valToRemove1) || expectedVal.equals(valToRemove2)) {
+                expectedVal++;
+                continue;
+            }
+            Assert.assertEquals(expectedVal, valIter.next());
+            Map.Entry<Integer, Integer> e = entryIter.next();
+            Assert.assertEquals(expectedVal, e.getKey());
+            Assert.assertEquals(expectedVal, e.getValue());
+            expectedVal++;
+
+        }
+
+    }
+
+    /**
+     * check how the iterator handles empty and sparse chunks
+     */
+    @Test
+    public void testSparsePopulation() {
+        int numOfItems = 10;
+        populate(numOfItems);
+
+        Iterator<Integer> valIter = oak.values().iterator();
+
+        Integer expectedVal = 0;
+        while (valIter.hasNext()) {
+            Assert.assertEquals(expectedVal, valIter.next());
+            expectedVal++;
+        }
+        Assert.assertEquals(expectedVal.intValue(), numOfItems);
+
+
+    }
+    private void populate(int numOfItems) {
+        for (Integer i = 0; i < numOfItems; i++) {
+            oak.zc().put(i, i);
+        }
+    }
 }


### PR DESCRIPTION
…ap/Basic (#191)

* removed MemoryMahager reference from OakMap

* added iterator to HashChunk, minor fixes in few other files

* commit to merge with latest master

* Update core/src/main/java/com/yahoo/oak/HashChunk.java

Co-authored-by: Anastasia Braginsky <anastas@yahoo-inc.com>

* OakHash iterators are implemented, not tested yet

* fixed a poblem in InternalOakHash::Iter::advance, removed unused code

* added common parent classes to IteratorState and Iter classes

* fixed get next chunk function

* added test for FirstLevelHashArray and for Hash Iterators

* no need to trach *csv files in benchmarks/synchrobench/output/

* moved commond fields to InternalOakBasics, addressed minor issues reviewed

* implemented iterator remove

* added message to assert, to understand weird fail in tests

* minor fixes ollowing Liran remarks

* added multithread test for OakHash and more tests for the iterator

* addressed Anaastasia comments

* fix minor merge problem

* renamed a test file to better fit the test description

* wrong class name fix

Co-authored-by: Boris Kapchits <bkapchits@oath.com>
Co-authored-by: Anastasia Braginsky <anastas@yahoo-inc.com>